### PR TITLE
Use built-in Chrome debugger and document repo layout

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,7 +5,7 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "type": "chrome",
+            "type": "pwa-chrome",
             "request": "launch",
             "name": "Launch Chrome against localhost",
             "url": "http://localhost:8080",

--- a/README.md
+++ b/README.md
@@ -1,2 +1,23 @@
 # hello-world
-"This repository is for practicing the GitHub Flow."
+
+This repository is a playground for experimenting with GitHub Flow and basic
+tooling configuration.
+
+## Repository structure
+
+- `LICENSE` – The MIT license covering this example project.
+- `.vscode/launch.json` – VS Code debug profile for launching the project in a
+  Chromium-based browser.
+
+Feel free to add additional folders such as `src/` for source code or `docs/`
+for documentation as you grow the project.
+
+## Debugging in VS Code
+
+1. Open the repository in VS Code.
+2. Ensure you have a development server running on `http://localhost:8080` (for
+   example, via `npm run dev` in a separate terminal).
+3. Press <kbd>F5</kbd> and select **Launch Chrome against localhost**.
+
+The launch configuration uses the built-in *pwa-chrome* debugger, so no extra
+extensions are required.


### PR DESCRIPTION
## Summary
- switch the VS Code launch configuration to use the built-in `pwa-chrome` debugger so it works without extra extensions
- expand the README with a structure overview and debugging instructions for newcomers

## Testing
- not run (no automated tests configured)


------
https://chatgpt.com/codex/tasks/task_e_688aa3ea89b083278334e3be40403b54